### PR TITLE
Update rvm version to `stable`

### DIFF
--- a/pivotal_workstation/attributes/versions.rb
+++ b/pivotal_workstation/attributes/versions.rb
@@ -1,5 +1,5 @@
 node.default['versions']= {
   "homebrew" => "master",
   "bash_it" => "5cb0ecc1c813bc5619e0f708b8015a4596a37d6c",
-  "rvm" => "d2c2e4d453f7b9723e63ebee3b0ea037f0c6bbad"
+  "rvm" => "stable"
 }

--- a/pivotal_workstation/changelog.md
+++ b/pivotal_workstation/changelog.md
@@ -1,0 +1,3 @@
+## 1.0.1.pre (unreleased)
+
+ * Update rvm version to `stable`

--- a/pivotal_workstation/metadata.rb
+++ b/pivotal_workstation/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email  "accounts@pivotallabs.com"
 license           "MIT"
 description       "Configure frequently-used tools for an OSX workstation"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0.0"
+version           "1.0.1.pre"
 supports          "mac_os_x"
 depends           "dmg"
 depends           "osx"


### PR DESCRIPTION
I don't know if you guys purposely wanted to keep an old version of rvm because of compatibility reasons, but I was running 1.19.1, and wanted to update to the latest, and so I updated the version to `stable`, which as of this writing is 1.19.6.

If you guys don't want to take this update, let me know, and just keep a separate copy in my fork. Thanks.
### Changes
- update pivotal_workstation/attributes/versions.rb and set rvm version to stable
- add pivotal_workstation/changelog.md
- up the pivotal_workstation version in meta data to 1.0.1.pre
