### PR TITLE
Update deprecated recipes to point to sprout-osx-settings.

### DIFF
--- a/pivotal_workstation/recipes/osx_aqua_color_preferences.rb
+++ b/pivotal_workstation/recipes/osx_aqua_color_preferences.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/osx_disable_natural_scrolling.rb
+++ b/pivotal_workstation/recipes/osx_disable_natural_scrolling.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/remove_expose_keyboard_shortcuts.rb
+++ b/pivotal_workstation/recipes/remove_expose_keyboard_shortcuts.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/remove_garageband.rb
+++ b/pivotal_workstation/recipes/remove_garageband.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/safari_preferences.rb
+++ b/pivotal_workstation/recipes/safari_preferences.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/set_finder_show_all_hd_on_desktop.rb
+++ b/pivotal_workstation/recipes/set_finder_show_all_hd_on_desktop.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/set_finder_show_hd_on_desktop.rb
+++ b/pivotal_workstation/recipes/set_finder_show_hd_on_desktop.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/set_finder_show_user_home_in_sidebar.rb
+++ b/pivotal_workstation/recipes/set_finder_show_user_home_in_sidebar.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/set_multitouch_preferences.rb
+++ b/pivotal_workstation/recipes/set_multitouch_preferences.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/set_start_up_automatically.rb
+++ b/pivotal_workstation/recipes/set_start_up_automatically.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/terminal_focus.rb
+++ b/pivotal_workstation/recipes/terminal_focus.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"

--- a/pivotal_workstation/recipes/terminal_preferences.rb
+++ b/pivotal_workstation/recipes/terminal_preferences.rb
@@ -1,2 +1,2 @@
-Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
-include_recipe "sprout-osx-apps::#{File.basename(__FILE__, '.rb')}"
+Chef::Log.warn "Please use sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"
+include_recipe "sprout-osx-settings::#{File.basename(__FILE__, '.rb')}"


### PR DESCRIPTION
I ran into this issue when upgrading to sprout. Commit dd2accdeb0e4c5c4cf47a40c51c95c91f6a3886b moved several recipes over to sprout-osx-settings. However, the corresponding deprecated recipes in pivotal_workstation are currently pointed at sprout-osx-apps, resulting in an error if you attempt to use them.
