### PR TITLE
Add enabled boolean to bash_it, default true

### DIFF
--- a/sprout-osx-base/attributes/bash_it.rb
+++ b/sprout-osx-base/attributes/bash_it.rb
@@ -17,5 +17,6 @@ node.default['bash_it'] ={
   'theme' => 'bobby',
   'dir' => ::File.expand_path(".bash_it", node['sprout']['home']),
   'bashrc_path' => ::File.expand_path(".bash_profile", node['sprout']['home']),
-  'repository' => 'http://github.com/revans/bash-it.git'
+  'repository' => 'http://github.com/revans/bash-it.git',
+  'enabled' => true
 }

--- a/sprout-osx-base/recipes/bash_it.rb
+++ b/sprout-osx-base/recipes/bash_it.rb
@@ -1,3 +1,5 @@
+return unless node["bash_it"]["enabled"] == true 
+
 bash_it_version = version_string_for('bash_it')
 
 git "#{Chef::Config[:file_cache_path]}/bash_it" do


### PR DESCRIPTION
I want to use homebrew but I dont want bash_it. I use zsh and would just rather not have bash_it installed.

I put and return unless test for `node.bash_it.enabled` at the top of the recipe and set the attribute to true. 

Is something like this ok or just pollution? 
