### PR TITLE
npm binaries on path

### DIFF
--- a/sprout-osx-base/templates/default/bash_it/custom/npm_bin_on_path.bash
+++ b/sprout-osx-base/templates/default/bash_it/custom/npm_bin_on_path.bash
@@ -1,0 +1,1 @@
+export PATH=$PATH:/usr/local/share/npm/bin


### PR DESCRIPTION
The NodeJS package manager, npm, when installed through Brew places it's binaries in a directory which is not on the path. This commit appends this directory to the path
