### PR TITLE
Move Vagrant's dmg_package source & checksum to attributes file

### DIFF
--- a/sprout-osx-apps/attributes/vagrant.rb
+++ b/sprout-osx-apps/attributes/vagrant.rb
@@ -1,0 +1,2 @@
+default['sprout']['vagrant']['dmg']['source']      = 'http://files.vagrantup.com/packages/be0bc66efc0c5919e92d8b79e973d9911f2a511f/Vagrant-1.0.5.dmg'
+default['sprout']['vagrant']['dmg']['checksum']    = 'd9ccdd454389f5830a8218c066c8f54c15d9d32ca6060bc42677b495aad08003'

--- a/sprout-osx-apps/recipes/vagrant.rb
+++ b/sprout-osx-apps/recipes/vagrant.rb
@@ -1,8 +1,10 @@
 include_recipe "sprout-osx-apps::virtualbox"
 
+dmg_properties = node['sprout']['vagrant']['dmg']
+
 dmg_package "Vagrant" do
-  source "http://files.vagrantup.com/packages/be0bc66efc0c5919e92d8b79e973d9911f2a511f/Vagrant-1.0.5.dmg"
-  checksum "d9ccdd454389f5830a8218c066c8f54c15d9d32ca6060bc42677b495aad08003"
+  source   dmg_properties['source']
+  checksum dmg_properties['checksum']
   action :install
   type "pkg"
   owner node['current_user']


### PR DESCRIPTION
On my local machine, I wanted to install a newer version of Vagrant, so I decided to move the dmg properties for the `sprout-osx-apps::vagrant` recipe to default attributes.  Then I can just add the version I want in my soloistrc.

This pull request doesn't change the behavior of the `sprout-osx-apps::vagrant` recipe, without custom node attributes, it still defaults to version 1.0.5 of Vagrant as before.
## Notes:

  By default, the recipe will use version 1.0.5 of Vagrant.
  To use a custom version of vagrant, put something like this in your
  soloistrc:

```
node_attributes:
  sprout:
    vagrant:
      dmg:
        source: http://files.vagrantup.com/packages/7e400d00a3c5a0fdf2809c8b5001a035415a607b/Vagrant-1.2.2.dmg
        checksum: 1581552841e076043308f330a5b1130b455c604846116c54b5330bb17240c7ee
```
