### PR TITLE
Point towards new ShiftIt binary location

### DIFF
--- a/pivotal_workstation/recipes/shiftit.rb
+++ b/pivotal_workstation/recipes/shiftit.rb
@@ -3,13 +3,13 @@ include_recipe "pivotal_workstation::addloginitem"
 app_path="/Applications/ShiftIt.app"
 
 unless File.exists?(app_path)
-  remote_file "#{Chef::Config[:file_cache_path]}/ShiftIt.app.zip" do
-    source "https://github.com/downloads/onsi/ShiftIt/ShiftIt.app.zip"
+  remote_file "#{Chef::Config[:file_cache_path]}/ShiftIt.zip" do
+    source "https://raw.github.com/onsi/ShiftIt/master/ShiftIt.zip"
     mode "0644"
   end
 
   execute "unzip ShiftIt" do
-    command "unzip #{Chef::Config[:file_cache_path]}/ShiftIt.app.zip ShiftIt.app/* -d /Applications/"
+    command "unzip #{Chef::Config[:file_cache_path]}/ShiftIt.zip ShiftIt.app/* -d /Applications/"
     user node['current_user']
     group "admin"
   end


### PR DESCRIPTION
I just bumped ShiftIt to 2.2 and changed its download URL.  This pull request points chef to the new URL.
