### PR TITLE
Updating default vagrant installed to 1.2.2

### DIFF
--- a/sprout-osx-apps/attributes/vagrant.rb
+++ b/sprout-osx-apps/attributes/vagrant.rb
@@ -1,2 +1,2 @@
-default['sprout']['vagrant']['dmg']['source']      = 'http://files.vagrantup.com/packages/be0bc66efc0c5919e92d8b79e973d9911f2a511f/Vagrant-1.0.5.dmg'
-default['sprout']['vagrant']['dmg']['checksum']    = 'd9ccdd454389f5830a8218c066c8f54c15d9d32ca6060bc42677b495aad08003'
+default['sprout']['vagrant']['dmg']['source']      = 'http://files.vagrantup.com/packages/7e400d00a3c5a0fdf2809c8b5001a035415a607b/Vagrant-1.2.2.dmg'
+default['sprout']['vagrant']['dmg']['checksum']    = '1581552841e076043308f330a5b1130b455c604846116c54b5330bb17240c7ee'


### PR DESCRIPTION
Note: Some things have changed in Vagrant 1.X.  Please see:
      http://docs.vagrantup.com/v2/installation/backwards-compatibility.html
