### PR TITLE
Move Adium's dmg_package source, checksum & volumes_dir to attributes file

### DIFF
--- a/sprout-osx-apps/attributes/adium.rb
+++ b/sprout-osx-apps/attributes/adium.rb
@@ -1,0 +1,3 @@
+default['sprout']['adium']['dmg']['source']      = 'http://sourceforge.net/projects/adium/files/Adium_1.5.6.dmg/download'
+default['sprout']['adium']['dmg']['checksum']    = 'd5f580b7db57348c31f8e0f18691d7758a65ad61471bf984955360f91b21edb8'
+default['sprout']['adium']['dmg']['volumes_dir'] = 'Adium 1.5.6'

--- a/sprout-osx-apps/recipes/adium.rb
+++ b/sprout-osx-apps/recipes/adium.rb
@@ -1,7 +1,9 @@
+dmg_properties = node['sprout']['adium']['dmg']
+
 dmg_package "Adium" do
-  volumes_dir "Adium 1.5.6"
-  source "http://sourceforge.net/projects/adium/files/Adium_1.5.6.dmg/download"
-  checksum "d5f580b7db57348c31f8e0f18691d7758a65ad61471bf984955360f91b21edb8"
+  volumes_dir dmg_properties['volumes_dir']
+  source      dmg_properties['source']
+  checksum    dmg_properties['checksum']
   action :install
   owner node['current_user']
 end


### PR DESCRIPTION
Notes:

  By default, the recipe will use version 1.5.6 of Adium.
  To use a custom version, put something like this in your
  soloistrc:

```
node_attributes:
  sprout:
    adium:
      dmg:
        source: http://sourceforge.net/projects/adium/files/Adium_1.5.7.dmg/download
        checksum: f80408a2c5bc97be8adb35ffeb7c4501392e847edae4e6e24d87da72de7e96b9
        volumes_dir: Adium 1.5.7
```
