### PR TITLE
Make sprout-osx-settings::remove_expose_keyboard_shortcuts recipe idempotent

### DIFF
--- a/sprout-osx-settings/recipes/remove_expose_keyboard_shortcuts.rb
+++ b/sprout-osx-settings/recipes/remove_expose_keyboard_shortcuts.rb
@@ -6,18 +6,10 @@ ruby_block "Remove Expose Keyboard Shortcut for '#{shortcut_name}'" do
     system(
     "osascript -e '
       tell application \"System Events\"
-        if UI elements enabled then
-          tell expose preferences
-            set the properties of the #{shortcut_name} shortcut to {function key:none, function key modifiers:{none}}
-            set the properties of the #{shortcut_name} shortcut to {function key:none}
-          end tell
-        else
-          tell application \"System Preferences\"
-            activate
-            set current pane to pane \"com.apple.preference.universalaccess\"
-            display dialog \"UI element scripting is not enabled. Check \\\"Enable access for assistive devices\\\"\"
-          end tell
-        end if
+        tell expose preferences
+          set the properties of the #{shortcut_name} shortcut to {function key:none, function key modifiers:{none}}
+          set the properties of the #{shortcut_name} shortcut to {function key:none}
+        end tell
       end tell'"
     )
   end


### PR DESCRIPTION
After many slow chef runs, I got a bit fed up of the system preferences
select box pane popping up & the delays caused by this recipe.

I was able to find a way to automate these preferences a bit faster, and
also a way to skip the ruby blocks if not necessary.

References:

[Scriptable System Preferences](http://www.macosxautomation.com/applescript/features/system-prefs.html)
[Reset FKey Script](http://askpascal.com/wiki/index.php/Reset_FKey_Script)
[Daring Fireball: How to Determine if a Certain App Is Running Using AppleScript and Perl](http://daringfireball.net/2006/10/how_to_tell_if_an_app_is_running)
