### PR TITLE
Move Chrome's dmg_package source, checksum & dmg_name to attributes file

### DIFF
--- a/sprout-osx-apps/attributes/chrome.rb
+++ b/sprout-osx-apps/attributes/chrome.rb
@@ -1,0 +1,3 @@
+default['sprout']['chrome']['dmg']['source']      = 'https://dl-ssl.google.com/chrome/mac/stable/GGRM/googlechrome.dmg'
+default['sprout']['chrome']['dmg']['checksum']    = '67de3a3a1d4a130912c5e31c9e2917585b3ec85b927d1498c89f9a360d4e052b'
+default['sprout']['chrome']['dmg']['dmg_name']    = 'googlechrome'

--- a/sprout-osx-apps/recipes/chrome.rb
+++ b/sprout-osx-apps/recipes/chrome.rb
@@ -1,7 +1,9 @@
+dmg_properties = node['sprout']['chrome']['dmg']
+
 dmg_package "Google Chrome" do
-  dmg_name "googlechrome"
-  source "https://dl-ssl.google.com/chrome/mac/stable/GGRM/googlechrome.dmg"
-  checksum "67de3a3a1d4a130912c5e31c9e2917585b3ec85b927d1498c89f9a360d4e052b"
+  dmg_name    dmg_properties['dmg_name']
+  source      dmg_properties['source']
+  checksum    dmg_properties['checksum']
   action :install
   owner node['current_user']
 end


### PR DESCRIPTION
Notes:

To use a custom version, put something like this in your soloistrc:

```
node_attributes:
 sprout:
   chrome:
     dmg:
       source: https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
       checksum: 6f4673c02ec38d4d8a480dc1e41caa97f49320ed9898bcbe1abde3272b636061
       dmg_name: googlechrome
```
