### PR TITLE
[issue #93] Added missing quotes inside git_config_global_defaults.rb

### DIFF
--- a/pivotal_workstation/recipes/git_config_global_defaults.rb
+++ b/pivotal_workstation/recipes/git_config_global_defaults.rb
@@ -41,7 +41,7 @@ ds \"diff --staged\"
 fixup \"commit --fixup\"
 squash \"commit --squash\"
 unstage \"reset HEAD\"
-rum rebase master@{u}
+rum \"rebase master@{u}\"
 EOF
 
 aliases.split("\n").each do |alias_string|


### PR DESCRIPTION
rum rebase master@{u} -> rum \"rebase master@{u}\"
This should take care of issue #93
