### PR TITLE
Fixing support for recursive git project checkout directories

### DIFF
--- a/pivotal_workstation/recipes/git_projects.rb
+++ b/pivotal_workstation/recipes/git_projects.rb
@@ -27,7 +27,7 @@ node['git_projects'].each do |repo_name, repo_address, repo_dir|
   repo_dir ||= node['workspace_directory']
 
   # Recursively create any directories under home (important if user passes multiple sub directories for repo dir)
-  recursive_directories [ "#{node['sprout']['home']}" ].concat repo_dir.split(File::SEPARATOR).delete_if(&:empty?) do
+  recursive_directories [ node['sprout']['home'] ].concat repo_dir.split(File::SEPARATOR).delete_if(&:empty?) do
     owner node['current_user']
     mode "0755"
     action :create


### PR DESCRIPTION
- Recursively create dirs to support nested subdirectory repo dirs
- Make sure repo dir is under workspace_directory if user has overriden
# Example Usage

Let's say you want to install a bunch of git projects in the following directory structure:

```
/Users/myuser/src
├── private
│   └── cookbooks
│       ├── secret-herbs-and-spices
│       └── secret-sauce
└── pub
    ├── cookbooks
    │   ├── apt
    │   └── ssmtp
    └── soloist-projects
        ├── sprout
        └── sprout-wrap
```

You would include this in your soloistrc:

```
recipes:
    - pivotal_workstation::git
    - pivotal_workstation::git_projects
    node_attributes:
      workspace_directory: src
      git_projects:
       - 
         - sprout-wrap
         - https://github.com/pivotal-sprout/sprout-wrap.git
         - pub/soloist-projects
       -
         - sprout
         - https://github.com/pivotal-sprout/sprout.git
         - pub/soloist-projects
       -
         - apt
         - https://github.com/opscode-cookbooks/apt.git
         - pub/cookbooks
       -
         - ssmtp
         - https://github.com/svanzoest/ssmtp-cookbook.git
         - pub/cookbooks
       - 
         - secret-sauce
         - https://github.com/pivotal/secret-sauce.git
         - private/cookbooks
       - 
         - secret-herbs-and-spices
         - https://github.com/pivotal/secret-herbs-and-spices.git
         - private/cookbooks
```
