### PR TITLE
Install MacVim without depending on XCode

### DIFF
--- a/sprout-osx-apps/attributes/macvim.rb
+++ b/sprout-osx-apps/attributes/macvim.rb
@@ -1,0 +1,5 @@
+default["sprout"]["macvim"]["source"]    = "https://macvim.googlecode.com/files/MacVim-snapshot-70-Mountain-Lion.tbz"
+default["sprout"]["macvim"]["checksum"]  = "45cbd33534ae121424d5411900ac68e32aa2aa7b097257defcdab0c6066f571b"
+default["sprout"]["macvim"]["extracted"] = "MacVim-snapshot-70"
+default["sprout"]["macvim"]["app"]       = "MacVim.app"
+default["sprout"]["macvim"]["bin"]       = "mvim"

--- a/sprout-osx-apps/recipes/macvim.rb
+++ b/sprout-osx-apps/recipes/macvim.rb
@@ -1,0 +1,32 @@
+source    = node["sprout"]["macvim"]["source"]
+checksum  = node["sprout"]["macvim"]["checksum"]
+extracted = node["sprout"]["macvim"]["extracted"]
+app       = node["sprout"]["macvim"]["app"]
+bin       = node["sprout"]["macvim"]["bin"]
+
+archive_name = File.basename(source)
+archive_path = "#{Chef::Config[:file_cache_path]}/#{archive_name}"
+
+remote_file archive_path do
+  source source
+  checksum checksum
+  owner node['current_user']
+end
+
+execute "extract #{archive_path}" do
+  command "tar -xvf #{archive_path} -C #{Chef::Config[:file_cache_path]}/"
+  not_if "test -e #{Chef::Config[:file_cache_path]}/#{extracted}"
+end
+
+execute "place #{app} in /Applications" do
+  command "cp -R #{Chef::Config[:file_cache_path]}/#{extracted}/#{app} /Applications/"
+  user node['current_user']
+  group "admin"
+  not_if "test -e /Applications/#{app}"
+end
+
+include_recipe "sprout-osx-base::user_owns_usr_local"
+execute "place #{bin} to /usr/local/bin" do
+  command "cp  #{Chef::Config[:file_cache_path]}/#{extracted}/#{bin} /usr/local/bin/"
+  not_if "test -e /usr/local/bin/#{bin}"
+end


### PR DESCRIPTION
The brew install in [pivotal_workstation::vim](https://github.com/pivotal-sprout/sprout/blob/master/pivotal_workstation/recipes/vim.rb) depends on a full XCode
install. This recipe works with just the standalone XCode CLI tools.

Replacing pivotal_workstation::vim with this recipe should help us get closer to being able to use a Vagrant vm to test Sprout: https://www.pivotaltracker.com/story/show/55764518
