### PR TITLE
osx_defaults does proper escaping

### DIFF
--- a/osx/providers/defaults.rb
+++ b/osx/providers/defaults.rb
@@ -1,6 +1,8 @@
+require 'shellwords'
+
 action :write do
   execute "#{new_resource.description} - #{new_resource.domain} - #{new_resource.key}"  do
-    command "defaults write #{new_resource.domain} #{new_resource.key} #{type_flag} #{value}"
+    command "defaults write #{new_resource.domain} #{key} #{type_flag} #{value}"
     user node['current_user']
     not_if "defaults read #{new_resource.domain} #{new_resource.key} | grep ^#{value}$"
   end
@@ -14,9 +16,13 @@ def type_flag
   ''
 end
 
+def key
+  Shellwords.escape(new_resource.key)
+end
+
 def value
   new_resource.integer ||
-    new_resource.string ||
+    new_resource.string && Shellwords.escape(new_resource.string) ||
     (new_resource.float && new_resource.float.to_f) ||
     new_resource.boolean
 end

--- a/sprout-osx-settings/recipes/terminal_preferences.rb
+++ b/sprout-osx-settings/recipes/terminal_preferences.rb
@@ -1,11 +1,11 @@
 osx_defaults "Set terminal color scheme to #{node['terminal']['color_scheme']}" do
   domain 'com.apple.Terminal'
-  key '"Default Window Settings"'
+  key 'Default Window Settings'
   string node['terminal']['color_scheme']
 end
 
 osx_defaults "Set startup terminal color scheme to #{node['terminal']['color_scheme']}" do
   domain 'com.apple.Terminal'
-  key '"Startup Window Settings"'
+  key 'Startup Window Settings'
   string node['terminal']['color_scheme']
 end


### PR DESCRIPTION
We now use Shellwords library to properly escape keys and values (if a
string type) of the default being written.  This way the users of this
utility don't have to worry about escaping things themselves.  This
required changing the terminal_preferences to no longer attempt to
excape some of it's keys.
