### PR TITLE
Install bundler with each version of ruby

### DIFF
--- a/pivotal_workstation/recipes/rbenv.rb
+++ b/pivotal_workstation/recipes/rbenv.rb
@@ -8,6 +8,20 @@ brew "ruby-build"
 
 sprout_osx_base_bash_it_enable_feature "plugins/rbenv"
 
+directory "#{::RBENV_HOME}/plugins" do
+  owner node["current_user"]
+end
+
+git "#{::RBENV_HOME}/plugins/rbenv-default-gems" do
+  repository "https://github.com/sstephenson/rbenv-default-gems.git"
+  user node["current_user"]
+end
+
+template "#{::RBENV_HOME}/default-gems" do
+  owner node['current_user']
+  source "default-gems.erb"
+end
+
 node["rbenv"]["rubies"].each do |version, options|
   rbenv_ruby_install version do
     options options

--- a/pivotal_workstation/templates/default/default-gems.erb
+++ b/pivotal_workstation/templates/default/default-gems.erb
@@ -1,0 +1,1 @@
+bundler


### PR DESCRIPTION
This installs the rbenv-default-gems plugin, which installs the list of gems specified in ~/.rbenv/default-gems each time a new version of ruby is installed.
