### PR TITLE
It's nice to have a jenkins recipe with some of the common plugins

### DIFF
--- a/sprout-osx-apps/attributes/jenkins.rb
+++ b/sprout-osx-apps/attributes/jenkins.rb
@@ -1,2 +1,3 @@
-default['sprout']['jenkins']['plugins'] = ['ruby-runtime', 'git-client', 'token-macro', 'rvm', 'git']
-default['sprout']['jenkins']['plugins_dir'] = "/Users/#{node['current_user']}/.jenkins/plugins"
+default['sprout']['jenkins']['plugins'] = ['ruby-runtime', 'ssh-agent', 'git-client', 'token-macro', 'rvm', 'git']
+default['sprout']['jenkins']['base_dir'] = "/Users/#{node['current_user']}/.jenkins"
+default['sprout']['jenkins']['plugins_dir'] = default['sprout']['jenkins']['base_dir'] + '/plugins'

--- a/sprout-osx-apps/recipes/jenkins.rb
+++ b/sprout-osx-apps/recipes/jenkins.rb
@@ -1,13 +1,17 @@
 include_recipe "sprout-osx-base::homebrew"
 jenkins_properties = node['sprout']['jenkins']
 
-brew "jenkins"
+directory jenkins_properties['base_dir'] do
+  action :create
+  owner node['current_user']
+end
 
 directory jenkins_properties['plugins_dir'] do
   action :create
   owner node['current_user']
-  recursive true
 end
+
+brew "jenkins"
 
 jenkins_properties['plugins'].each do |plugin|
   execute "install #{plugin} plugin" do


### PR DESCRIPTION
We've added a basic jenkins recipe which installs the Git and Rvm plugins. With these plugins, the Jenkins installation should be good to go for most Pivotal projects (especially iOS projects that use Thrust).

Note that our installed version of Jenkins comes from homebrew.
