### PR TITLE
Copy VLC attributes into sprout-osx-apps, update to version 2.08

### DIFF
--- a/sprout-osx-apps/attributes/vlc.rb
+++ b/sprout-osx-apps/attributes/vlc.rb
@@ -1,0 +1,2 @@
+node.default["vlc_version"]="2.0.8"
+node.default["vlc_checksum"]="bbfdc6d10d9f3a4d357d276d9c6db9c049e637fa2cc54fa511f0fce914a38ea0"


### PR DESCRIPTION
Copied from pivotal_workstation/attributes/vlc.rb and updated for version 2.0.8. VLC recipe had moved but attributes had not.

→ cat pivotal_workstation/recipes/vlc.rb
Chef::Log.warn "Please use sprout-osx-apps::#{File.basename(**FILE**, '.rb')}"
include_recipe "sprout-osx-apps::#{File.basename(**FILE**, '.rb')}"
