### PR TITLE
Change 'o' --> 'p' in the word 'sorout' inside attributes/nitrous.rb

### DIFF
--- a/sprout-osx-apps/attributes/nitrous.rb
+++ b/sprout-osx-apps/attributes/nitrous.rb
@@ -1,3 +1,3 @@
 default['sprout']['nitrous']['source']   = 'https://www.nitrous.io/mac/Nitrous-Mac-Latest.zip'
-default['sorout']['nitrous']['checksum'] = '8eb4407cd0b327e1e9fbdd1ee165a58a959be861911b1dbfea86f6558a6dd59a' # Corresponds to 0.1.7
+default['sprout']['nitrous']['checksum'] = '8eb4407cd0b327e1e9fbdd1ee165a58a959be861911b1dbfea86f6558a6dd59a' # Corresponds to 0.1.7
 default['sprout']['nitrous']['app']      = 'Nitrous.app'


### PR DESCRIPTION
The result of this bug is that the checksum wasn't getting validated inside the nitrous recipe 
