### PR TITLE
Sprout 111 update onyx version

### DIFF
--- a/sprout-osx-apps/recipes/onyx.rb
+++ b/sprout-osx-apps/recipes/onyx.rb
@@ -1,5 +1,5 @@
 dmg_package "Onyx" do
-  volumes_dir "Onyx 2.7.2"
+  volumes_dir "Onyx 2.7.3"
   source "http://joel.barriere.pagesperso-orange.fr/dl/108/OnyX.dmg"
   checksum '0a94c54851db7d148c4d5db6f035e666dfee8f0d55632739c8eeef98e05bdab8'
   action :install


### PR DESCRIPTION
So looks like it's actually 2.7.3 now.  Sad how out of all the mirrors online to download this dmg, not one is direct link-able except the author's site, and that link doesn't have a static version.  Seems like he updates the version but uses the same url, so we'll always have the right link to latest but not version or checksum :-\

Fixes #111
