### PR TITLE
Updated Java version

### DIFF
--- a/sprout-osx-apps/attributes/java.rb
+++ b/sprout-osx-apps/attributes/java.rb
@@ -1,3 +1,3 @@
 default['sprout']['java']['dmg']['source']      = "http://support.apple.com/downloads/DL1572/en_US/JavaForOSX2013-05.dmg"
 default['sprout']['java']['dmg']['volumes_dir'] = "Java for OS X 2013-005"
-default['sprout']['java']['dmg']['checksum']    = "ce78f9a916b91ec408c933bd0bde5973ca8a2dc4"
+default['sprout']['java']['dmg']['checksum']    = "81e1155e44b2c606db78487ca1a02e31dbb3cfbf7e0581a4de3ded9e635a704e"


### PR DESCRIPTION
The previous version was no longer available.
The new version can be found here: http://support.apple.com/kb/DL1572
