### PR TITLE
Updated F.lux download uri

### DIFF
--- a/sprout-osx-apps/attributes/flux.rb
+++ b/sprout-osx-apps/attributes/flux.rb
@@ -1,2 +1,2 @@
-node.default["flux_download_uri"]="https://herf.org/flux/Flux.zip"
-node.default["flux_download_checksum"]="c4cb2b2e08c07678e4825c7472f78fe8fca8e78846625dcb7a4fe4fcae503471"
+node.default["flux_download_uri"]="https://justgetflux.com/mac/Flux.zip"
+node.default["flux_download_checksum"]="7cc07a4865b45f6e9b4736b5eb25db21e16bbcd36ce447fee54394ccb9a0d360"


### PR DESCRIPTION
Updated the F.lux recipe to use the new url, since the old one wasn't working anymore.
