### PR TITLE
Use homebrew cask for gpgtools

### DIFF
--- a/sprout-osx-apps/recipes/gpgtools.rb
+++ b/sprout-osx-apps/recipes/gpgtools.rb
@@ -1,8 +1,1 @@
-dmg_package "GPGTools" do
-  source 'https://s3.amazonaws.com/gpgtools/GPGTools-2013.5.20.dmg'
-  checksum '032780e5fc4712410acd8d122aa833134ab4c87eb37b5c735e9f623f0720d387'
-  type 'pkg'
-  package_id 'org.gpgtools.*'
-  action :install
-  owner node['current_user']
-end
+sprout_osx_apps_homebrew_cask 'gpgtools'


### PR DESCRIPTION
With respect to #84 ... this PR delegates to the homebrew cask for installing gpgtools.

Note that the current version in homebrew is not latest, but if they update or upgrade, it should work.
