### PR TITLE
Update bash-it sha to latest for chruby support

### DIFF
--- a/sprout-osx-base/attributes/versions.rb
+++ b/sprout-osx-base/attributes/versions.rb
@@ -1,1 +1,1 @@
-node.default['versions']['bash_it'] = '5cb0ecc1c813bc5619e0f708b8015a4596a37d6c'
+node.default['versions']['bash_it'] = '8bf641baec4316cebf1bc1fd2757991f902506dc'


### PR DESCRIPTION
- existing version is from Aug 2012
- changes: https://github.com/revans/bash-it/compare/5cb0ecc...8bf641b

I tested the recipe on Mountain Lion to no ill effect, and have been using the latest version of bash-it on Mavericks for over a week.
