### PR TITLE
Add the output of rbenv gemset to the ruby version string

### DIFF
--- a/sprout-osx-base/templates/default/bash_it/custom/add_gemset_to_rbenv_prompt.bash
+++ b/sprout-osx-base/templates/default/bash_it/custom/add_gemset_to_rbenv_prompt.bash
@@ -1,0 +1,10 @@
+function rbenv_version_prompt {
+  if which rbenv &> /dev/null; then
+    rbenv=$(rbenv version-name) || return
+    gemset=$(rbenv gemset active 2> /dev/null | sed 's% %+%')
+    if [ -n "$gemset" ]; then
+      rbenv="$rbenv@$gemset"
+    fi
+    echo -e "$RBENV_THEME_PROMPT_PREFIX$rbenv$RBENV_THEME_PROMPT_SUFFIX"
+  fi
+}


### PR DESCRIPTION
- This brings the outward appearance of the bash-it prompt when using rbenv closer to what it was with rvm
- Requires the use of rbenv gemset: https://github.com/jamis/rbenv-gemset
