### PR TITLE
Fix path issue when running on a fresh box

### DIFF
--- a/pivotal_workstation/recipes/sublime_text.rb
+++ b/pivotal_workstation/recipes/sublime_text.rb
@@ -20,7 +20,7 @@ end
 node["sublime_text_packages"].each do |package|
   pivotal_workstation_sublime_package package["name"] do
     source package["source"]
-    destination File.join(sublime_package_path)
+    destination File.join(*sublime_package_path)
     owner node['current_user']
   end
 end


### PR DESCRIPTION
Observed this failure on a fresh on Mavericks.

```
Recipe: <Dynamically Defined Resource>
*execute[brew cask install sublime-text]...
==> Downloading ...
(kaboom, please report this error to homebrew)
```
