### PR TITLE
Macvim needs to be compiled with ruby from a Mavericks OSX installation

### DIFF
--- a/sprout-osx-apps/attributes/macvim.rb
+++ b/sprout-osx-apps/attributes/macvim.rb
@@ -1,5 +1,5 @@
-default["sprout"]["macvim"]["source"]    = "https://macvim.googlecode.com/files/MacVim-snapshot-70-Mountain-Lion.tbz"
-default["sprout"]["macvim"]["checksum"]  = "45cbd33534ae121424d5411900ac68e32aa2aa7b097257defcdab0c6066f571b"
-default["sprout"]["macvim"]["extracted"] = "MacVim-snapshot-70"
+default["sprout"]["macvim"]["source"]    = "https://github.com/b4winckler/macvim/releases/download/snapshot-72/MacVim-snapshot-72-Mavericks.tbz"
+default["sprout"]["macvim"]["checksum"]  = "f2543860b27b7c0db9407d9d38d4c2fb5cda5b23845a6c121936116ccf8b0d39"
+default["sprout"]["macvim"]["extracted"] = "MacVim-snapshot-72"
 default["sprout"]["macvim"]["app"]       = "MacVim.app"
 default["sprout"]["macvim"]["bin"]       = "mvim"


### PR DESCRIPTION
This fixes the issue with the recipe vim_config 

https://github.com/pivotal-sprout/sprout/issues/149
