### PR TITLE
`brew install postgresql` now handles the `initdb` command

### DIFF
--- a/pivotal_workstation/recipes/postgres.rb
+++ b/pivotal_workstation/recipes/postgres.rb
@@ -24,11 +24,6 @@ run_unless_marker_file_exists("postgres") do
 
   package "postgresql"
 
-  execute "create the database" do
-    command "/usr/local/bin/initdb -U postgres --encoding=utf8 --locale=en_US /usr/local/var/postgres"
-    user node['current_user']
-  end
-
   launch_agents_path = File.expand_path('.', File.join('~','Library', 'LaunchAgents'))
   directory launch_agents_path do
     action :create


### PR DESCRIPTION
See: https://github.com/mxcl/homebrew/commit/63007d6aae27c1016dd4779b011a6698d149b21c

No longer need to run `soloist` twice any longer. :)

https://github.com/pivotal-sprout/sprout/issues/149
