### PR TITLE
change default rvm ruby installation to ruby 2 p353

### DIFF
--- a/pivotal_workstation/attributes/rvm.rb
+++ b/pivotal_workstation/attributes/rvm.rb
@@ -4,7 +4,7 @@ node.default["rvm"]["rubies"] = {
   # "ruby-1.8.7-p358" => { :env => "CC=gcc-4.2" },
   # "ruby-1.9.2-p290" => { :env => "CC=gcc-4.2" },
   # "ruby-1.9.3-p194" => { :command_line_options => "--with-gcc=clang" }
-  "ruby-2.0.0-p247" => { :command_line_options => "--verify-downloads 1" }
+  "ruby-2.0.0-p353" => { :command_line_options => "--verify-downloads 1" }
 }
 
-node.default["rvm"]["default_ruby"] = "ruby-2.0.0-p247"
+node.default["rvm"]["default_ruby"] = "ruby-2.0.0-p353"


### PR DESCRIPTION
Ruby 2.0.0 p 247 happily installs in Mavericks, whereas 1.9.3 does not still. 

References https://github.com/pivotal-sprout/sprout/issues/149
