### PR TITLE
Make homebrew cask installations easy!

### DIFF
--- a/sprout-osx-apps/attributes/homebrew_cask_apps.rb
+++ b/sprout-osx-apps/attributes/homebrew_cask_apps.rb
@@ -1,0 +1,2 @@
+default["brew_cask_applications"] = []
+

--- a/sprout-osx-apps/recipes/homebrew_cask_apps.rb
+++ b/sprout-osx-apps/recipes/homebrew_cask_apps.rb
@@ -1,0 +1,5 @@
+include_recipe "sprout-osx-apps::homebrew_cask"
+
+node["brew_cask_applications"].each do |application|
+  sprout_osx_apps_homebrew_cask application
+end


### PR DESCRIPTION
To add applications to be installed via homebrew-cask, in `soloistrc`

``` yaml
node_attributes:
  brew_cask_applications:
  - limechat
  - phpstorm
  - wunderlist
  - arduino
  - air_video_server
```
