### PR TITLE
Only push current git branch to upstream with simple push.default.

### DIFF
--- a/pivotal_workstation/recipes/git_config_global_defaults.rb
+++ b/pivotal_workstation/recipes/git_config_global_defaults.rb
@@ -92,3 +92,8 @@ execute "set rebase autosquash=true" do
   command "git config --global rebase.autosquash true"
   user node['current_user']
 end
+
+execute "set push.default to simple" do
+  command "git config --global push.default simple"
+  user node['current_user']
+end


### PR DESCRIPTION
This squelches a common message on git installations post 1.7, and sets git to more intuitive functionality.

See http://stackoverflow.com/questions/13148066/warning-push-default-is-unset-its-implicit-value-is-changing-in-git-2-0 for explanation
