### PR TITLE
Fix adding home dir to Finder sidebar

### DIFF
--- a/sprout-osx-settings/recipes/set_finder_show_user_home_in_sidebar.rb
+++ b/sprout-osx-settings/recipes/set_finder_show_user_home_in_sidebar.rb
@@ -9,7 +9,7 @@ ruby_block "Show User Home In Sidebar" do
         set user_home to folder \"#{username}\" of folder \"Users\" of Startup disk
         select user_home
         delay 1
-        tell application \"System Events\" to tell process \"Finder\" to keystroke \"t\" using command down
+        tell application \"System Events\" to tell process \"Finder\" to keystroke \"t\" using {command down, control down}
         close window 1
       end tell'"
     )


### PR DESCRIPTION
It appears the keyboard shortcut has changed and now the control modifier key is required to add an item to sidebar.
