### PR TITLE
Removed old flux attributes

### DIFF
--- a/sprout-osx-apps/attributes/flux.rb
+++ b/sprout-osx-apps/attributes/flux.rb
@@ -1,2 +1,0 @@
-node.default["flux_download_uri"]="https://herf.org/flux/Flux.zip"
-node.default["flux_download_checksum"]="c4cb2b2e08c07678e4825c7472f78fe8fca8e78846625dcb7a4fe4fcae503471"


### PR DESCRIPTION
Earlier I made a pull-request to update flux, it was without cask, see pull #156. It seems Alex Stupakov already fixed flux on Nov. 27, but the old attributes weren't removed. So here is some cleanup
