### PR TITLE
Update homebrew repo URL

### DIFF
--- a/sprout-osx-base/attributes/homebrew.rb
+++ b/sprout-osx-base/attributes/homebrew.rb
@@ -1,4 +1,4 @@
 node.default['homebrew'] = {
     'version' => 'master',
-    'repository' => 'http://github.com/mxcl/homebrew.git'
+    'repository' => 'http://github.com/Homebrew/homebrew.git'
 }


### PR DESCRIPTION
The homebrew repo URL has moved and the attribute specifying it needs updating.
