### PR TITLE
Fix bugs when trying to specify rubies in soloistrc without an env hash

### DIFF
--- a/sprout-osx-rbenv/definitions/ruby_install.rb
+++ b/sprout-osx-rbenv/definitions/ruby_install.rb
@@ -12,7 +12,7 @@ define :ruby_install do
     user params[:user] || node['current_user']
     only_if params[:only_if] if params[:only_if]
     not_if params[:not_if] || "#{rbenv_cmd} versions | grep #{ruby_version}"
-    env params[:options][:env]
+    env options[:env]
   end
 
   execute "check #{ruby_version}" do


### PR DESCRIPTION
When trying to specify rubies in my sprout-wrap soloistrc like this:

```
  sprout:
    rbenv:
      rubies:
        - 2.0.0-p353
        - 1.9.3-p448
```

… I get the error…

```
 ================
Recipe Compile Error in /Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/recipes/default.rb
=================


NoMethodError
-------------
undefined method `[]' for nil:NilClass


Cookbook Trace:
---------------
  /Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/definitions/ruby_install.rb:15:in `block (2 levels) in from_file'
  /Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/definitions/ruby_install.rb:10:in `block in from_file'
  /Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/recipes/default.rb:10:in `block in from_file'
  /Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/recipes/default.rb:9:in `each'
  /Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/recipes/default.rb:9:in `from_file'


Relevant File Content:
----------------------
/Users/kfitzpatrick/workspace/sprout-wrap/cookbooks/sprout-osx-rbenv/definitions/ruby_install.rb:

  8:    install_cmd = "#{rbenv_cmd} install #{ruby_version} #{options[:command_line_options]}"
  9:
 10:    execute "installing #{ruby_version} with RBENV: #{install_cmd}" do
 11:      command install_cmd
 12:      user params[:user] || node['current_user']
 13:      only_if params[:only_if] if params[:only_if]
 14:      not_if params[:not_if] || "#{rbenv_cmd} versions | grep #{ruby_version}"
 15>>     env params[:options][:env]
 16:    end
 17:
 18:    execute "check #{ruby_version}" do
 19:      command "#{rbenv_cmd} versions | grep #{ruby_version}"
 20:      user params[:user] || node['current_user']
 21:    end
 22:  end
 23:
```

This PR solves my problem :)
