### PR TITLE
Remove git warning by adding push default

### DIFF
--- a/pivotal_workstation/recipes/git_config_global_defaults.rb
+++ b/pivotal_workstation/recipes/git_config_global_defaults.rb
@@ -92,3 +92,8 @@ execute "set rebase autosquash=true" do
   command "git config --global rebase.autosquash true"
   user node['current_user']
 end
+
+execute "set push default=simple" do
+  command "git config --global push.default simple"
+  user node['current_user']
+end


### PR DESCRIPTION
When push.default is unset git shows a warning message when you push. Set the push.default to 'simple' which will be the implicit value for Git 2.0.
