### PR TITLE
Add no-op default recipe to sprout-osx-base

### DIFF
--- a/sprout-osx-base/recipes/default.rb
+++ b/sprout-osx-base/recipes/default.rb
@@ -1,0 +1,1 @@
+# A no-op recipe to load attributes.


### PR DESCRIPTION
In order to make sprout work on ubuntu machines, we need to load sprout-osx-base attributes. All the recipes in this cookbook are osx specific, but some of the attributes are needed for non-osx recipes, so a no-op default.rb would allow the attrs to be loaded.
