### PR TITLE
Adds recipe to update the date/time format of the clock in the menubar

### DIFF
--- a/sprout-osx-settings/attributes/set_menubar_clock_format.rb
+++ b/sprout-osx-settings/attributes/set_menubar_clock_format.rb
@@ -1,0 +1,2 @@
+#see http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
+node.default['sprout']['settings']['clock_format'] = 'EEE MMM d  h:mm:ss a'

--- a/sprout-osx-settings/recipes/set_menubar_clock_format.rb
+++ b/sprout-osx-settings/recipes/set_menubar_clock_format.rb
@@ -1,0 +1,6 @@
+clock_format = node['sprout']['settings']['clock_format']
+osx_defaults 'turn on date & seconds for menubar clock' do
+  domain 'com.apple.menuextra.clock'
+  key 'DateFormat'
+  string clock_format
+end


### PR DESCRIPTION
The default format causes the clock to look like 'Tue Mar 18 8:22:07 PM' and
there is an attribute sprout->settings->clock_format to allow overriding.
There is also a link in the attributes file as to where to look for the
formatting options.
