### PR TITLE
Specify name in metadata to fix Ridley::Errors::MissingNameAttribute

### DIFF
--- a/pivotal_workstation/metadata.rb
+++ b/pivotal_workstation/metadata.rb
@@ -1,3 +1,4 @@
+name              "pivotal_workstation"
 maintainer        "Pivotal Labs"
 maintainer_email  "accounts@pivotallabs.com"
 license           "MIT"


### PR DESCRIPTION
In Ridley 3.0 ( used in berkshelf 3.0 ) it's mandatory to declare name
attribute in cookbook's metadata.rb )

Otherwise we get this error:

```
Ridley::Errors::MissingNameAttribute The metadata at '/var/folders/ty/tgf8y4xd55s5hxvmv4xbg7sc0000gn/T/d20140416-98615-1pwiypi' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
```
