### PR TITLE
Use xterm-256color for $TERM in iTerm preferences

### DIFF
--- a/sprout-osx-apps/files/default/com.googlecode.iterm2.plist
+++ b/sprout-osx-apps/files/default/com.googlecode.iterm2.plist
@@ -970,7 +970,7 @@
 			<key>Tags</key>
 			<array/>
 			<key>Terminal Type</key>
-			<string>xterm</string>
+			<string>xterm-256color</string>
 			<key>Transparency</key>
 			<real>0.0</real>
 			<key>Unlimited Scrollback</key>


### PR DESCRIPTION
This way, we can run terminal applications such as vim in 256-color mode
