### PR TITLE
Update gitx-rowanj cask name

### DIFF
--- a/recipes/gitx.rb
+++ b/recipes/gitx.rb
@@ -1,1 +1,1 @@
-homebrew_cask "gitx-rowanj"
+homebrew_cask "rowanj-gitx"


### PR DESCRIPTION
The cask name appears to have changed. Ran into this today.