### PR TITLE
Fixes black color not showing up against dark background

### DIFF
--- a/files/default/com.googlecode.iterm2.plist
+++ b/files/default/com.googlecode.iterm2.plist
@@ -436,11 +436,11 @@
 			<key>Ansi 8 Color</key>
 			<dict>
 				<key>Blue Component</key>
-				<real>0.15170273184776306</real>
+				<real>1</real>
 				<key>Green Component</key>
-				<real>0.11783610284328461</real>
+				<real>1</real>
 				<key>Red Component</key>
-				<real>0.0</real>
+				<real>1</real>
 			</dict>
 			<key>Ansi 9 Color</key>
 			<dict>


### PR DESCRIPTION
Was hiding line number output from nightwatch spec failures
